### PR TITLE
feat: add local caching for products using SharedPreferences

### DIFF
--- a/lib/core/error/failures.dart
+++ b/lib/core/error/failures.dart
@@ -29,6 +29,17 @@ class ServerFailure extends Failure {
   int get getStatusCode => errorObject?.response?.statusCode ?? 0;
 }
 
+class CacheFailure extends Failure {
+  final String message;
+
+  CacheFailure({required this.message});
+
+  @override
+  String get getErrorMessage => message;
+
+  @override
+  int get getStatusCode => -1; // custom non-HTTP code
+}
 
 class OfflineFailure extends Failure {
   final String message;

--- a/lib/features/products/data/data_sources/products_local_data_source.dart
+++ b/lib/features/products/data/data_sources/products_local_data_source.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'package:holo_products_app/core/error/exceptions.dart';
+import 'package:holo_products_app/features/products/data/models/product_model.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+abstract class ProductsLocalDataSource {
+  /// Gets the cached list of products from local storage.
+  /// Throws a [CacheException] if no data is found.
+  Future<List<ProductModel>> getLastProducts();
+
+  /// Caches the products data locally.
+  Future<void> cacheProducts(List<ProductModel> products);
+}
+
+const CACHED_PRODUCTS = 'CACHED_PRODUCTS';
+
+class ProductsLocalDataSourceImpl implements ProductsLocalDataSource {
+  final SharedPreferences sharedPreferences;
+
+  ProductsLocalDataSourceImpl({required this.sharedPreferences});
+
+  @override
+  Future<List<ProductModel>> getLastProducts() {
+    final jsonString = sharedPreferences.getString(CACHED_PRODUCTS);
+    if (jsonString != null) {
+      return Future.value(productsEntityFromJson(jsonString));
+    } else {
+      throw CacheException();
+    }
+  }
+
+  @override
+  Future<void> cacheProducts(List<ProductModel> products) {
+    final jsonString = jsonEncode(products.map((p) => p.toJson()).toList());
+    return sharedPreferences.setString(CACHED_PRODUCTS, jsonString);
+  }
+}

--- a/lib/features/products/data/repositories/products_repository_impl.dart
+++ b/lib/features/products/data/repositories/products_repository_impl.dart
@@ -3,27 +3,36 @@ import 'package:holo_products_app/core/error/error_strings/failures.dart';
 import 'package:holo_products_app/core/error/exceptions.dart';
 import 'package:holo_products_app/core/error/failures.dart';
 import 'package:holo_products_app/core/network/network_info.dart';
+import 'package:holo_products_app/features/products/data/data_sources/products_local_data_source.dart';
 import 'package:holo_products_app/features/products/data/data_sources/products_remote_data_source.dart';
 import 'package:holo_products_app/features/products/domain/entities/product_entity.dart';
 import 'package:holo_products_app/features/products/domain/repositories/products_repository.dart';
 
 class ProductsRepositoryImpl implements ProductsRepository{
   final ProductsRemoteDataSource remoteDataSource;
+  final ProductsLocalDataSource localDataSource;
   final NetworkInfo networkInfo;
 
-  ProductsRepositoryImpl(
-      {required this.remoteDataSource, required this.networkInfo});
+  ProductsRepositoryImpl({required this.remoteDataSource, required this.networkInfo,required this.localDataSource });
 
   @override
   Future<Either<Failure, List<ProductEntity>>> getProducts() async {
     if (await networkInfo.isConnected) {
       try {
-        final response = await remoteDataSource.getProducts();
-        return Right(response);
+        final remoteProducts = await remoteDataSource.getProducts();
+        await localDataSource.cacheProducts(remoteProducts);
+        return Right(remoteProducts);
       } on ServerException catch (serverex) {
         return Left(ServerFailure(errorObject: serverex.getErrorObject()));
       }
     } else {
+      print("Not connected");
+      try {
+        final localProducts = await localDataSource.getLastProducts();
+        return Right(localProducts);
+      } on CacheException {
+        return Left(CacheFailure(message: FailureMessages.CACHE_FAILURE_MESSAGE));
+      }
       return Left(OfflineFailure(message: FailureMessages.OFFLINE_FAILURE_MESSAGE));
     }
   }

--- a/lib/injection_container.dart
+++ b/lib/injection_container.dart
@@ -4,11 +4,13 @@ import 'package:dio/dio.dart';
 import 'package:get_it/get_it.dart';
 import 'package:holo_products_app/core/network/network_info.dart';
 import 'package:holo_products_app/core/utils/AEDGenerator.dart';
+import 'package:holo_products_app/features/products/data/data_sources/products_local_data_source.dart';
 import 'package:holo_products_app/features/products/data/data_sources/products_remote_data_source.dart';
 import 'package:holo_products_app/features/products/data/repositories/products_repository_impl.dart';
 import 'package:holo_products_app/features/products/domain/repositories/products_repository.dart';
 import 'package:holo_products_app/features/products/domain/usecases/get_products_usecase.dart';
 import 'package:holo_products_app/features/products/presentation/bloc/products_bloc.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'core/utils/server_response.dart';
 final sl = GetIt.instance;
@@ -26,6 +28,8 @@ Future<void> initializeDependencies() async {
 
   //!External
   sl.registerLazySingleton(() => Dio());
+  final sharedPreferences = await SharedPreferences.getInstance();
+  sl.registerLazySingleton(() => sharedPreferences);
 
 }
 
@@ -37,6 +41,7 @@ getProducts(){
   //Datasource
   sl.registerLazySingleton<ProductsRemoteDataSource>(() =>ProductsRemoteDataSourceImpl( dio: sl(), ));
   //repository
-  sl.registerLazySingleton<ProductsRepository>(() =>ProductsRepositoryImpl(networkInfo: sl(), remoteDataSource: sl()));
+  sl.registerLazySingleton<ProductsRepository>(() =>ProductsRepositoryImpl(networkInfo: sl(), remoteDataSource: sl(),localDataSource: sl() ));
+  sl.registerLazySingleton<ProductsLocalDataSource>(() => ProductsLocalDataSourceImpl(sharedPreferences: sl()),);
 
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,9 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import path_provider_foundation
+import shared_preferences_foundation
 import sqflite_darwin
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -488,6 +488,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "5bcf0772a761b04f8c6bf814721713de6f3e5d9d89caf8d3fe031b02a342379e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.11"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shimmer:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
+  shared_preferences: ^2.2.0
   flutter_native_splash: ^2.4.6
   intl: ^0.20.2
   cached_network_image: ^3.3.1


### PR DESCRIPTION
- Implemented ProductsLocalDataSource for storing and retrieving cached products
- Integrated local data source into ProductsRepositoryImpl
- Updated dependency injection to register local data source and SharedPreferences
- Added CacheFailure handling in repository for offline scenarios